### PR TITLE
Onofre: Use image path specified in YAML

### DIFF
--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -60,7 +60,7 @@
       <div class="row pt-5 align-items-center">
         <div class="col-12 col-lg-6">
           <div class="pl-5 pb-4">
-            <img src="herzl.jpg" style="height:12rem" class="rounded-circle">
+            <img src=$image$ style="height:12rem" class="rounded-circle">
           </div>
           <div class="pl-5 py-1">
             <h1>$title$</h1>


### PR DESCRIPTION
Hi, thanks for the great package. This PR inserts the pandoc variable `image` into the Onofre template. Currently, it is not possible to replace the default image.