### PR TITLE
Added support for favicons and icons in social buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,15 @@ The HTML file can then be easily deployed to
 ---
 title: "Tobi Burns"
 image: "tobi.jpg"
-links:
-  - LinkedIn: "https://linkedin.com/"
-  - Twitter: "https://twitter.com/"
-  - GitHub: "https://github.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - LinkedIn: 
+      link: "https://linkedin.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - GitHub: 
+      link: "https://github.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::jolla
 ---
@@ -77,11 +81,15 @@ true crime podcasts, and causal inference.
 ---
 title: "Xiang Guo"
 image: "xiang.jpg"
-links:
-  - LinkedIn: "https://linkedin.com/"
-  - Twitter: "https://twitter.com/"
-  - GitHub: "https://github.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - LinkedIn: 
+      link: "https://linkedin.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - GitHub: 
+      link: "https://github.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::jolla_blue
 ---
@@ -100,11 +108,15 @@ turnip prices.
 ---
 title: "Frank Hermosillo"
 image: "frank.jpg"
-links:
-  - LinkedIn: "https://linkedin.com/"
-  - Twitter: "https://twitter.com/"
-  - GitHub: "https://github.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - LinkedIn: 
+      link: "https://linkedin.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - GitHub: 
+      link: "https://github.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::trestles
 ---
@@ -146,11 +158,15 @@ image: "herzl.jpg"
 color1: "#5A59A3"
 color2: "#C66060"
 angle: 130
-links:
-  - YouTube: "https://youtube.com/"
-  - Vimeo: "https://vimeo.com/"
-  - Twitter: "https://twitter.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - YouTube: 
+      link: "https://youtube.com/"
+  - Vimeo: 
+      link: "https://vimeo.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::onofre
 ---

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -35,12 +35,12 @@
 
           <div class="d-none d-sm-block" id="icon-list">
             <ul class="list-inline">
-              $for(links)$
+              $for(socials)$
               $for(it/pairs)$
               <li class="list-inline-item">
-                <a href=$it.value$>
+                <a href=$it.value.link$ target="_blank">
                   <button type="button" class="btn btn-outline-light">
-                    $it.key$
+                    $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                   </button>
                 </a>
               </li>
@@ -52,11 +52,11 @@
           <div class="row justify-content-center align-items-center">
             <div class="col-8 m-1 text-center d-block d-sm-none">
               <div class="list-group">
-                $for(links)$
+                $for(socials)$
                 $for(it/pairs)$
-                <a href=$it.value$>
+                <a href=$it.value.link$ target="_blank">
                   <button type="button" class="list-group-item list-group-item-action my-1 rounded" style="background-color: #3A66B7;color: #FEFEFA;border-color: #FEFEFA;">
-                    $it.key$
+                    $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                   </button>
                 </a>
                 $endfor$

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -13,6 +13,10 @@
 
     <title>$title$</title>
 
+    $if(favicon)$
+      <link rel="shortcut icon" href="$favicon$" />
+    $endif$
+
   </head>
   <body>
     <div class="container min-vh-100">

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -10,6 +10,10 @@
 
     <title>$title$</title>
 
+    $if(favicon)$
+      <link rel="shortcut icon" href="$favicon$" />
+    $endif$
+
   </head>
   <body>
     <div class="container min-vh-100">

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -32,12 +32,12 @@
 
           <div class="d-none d-sm-block" id="icon-list">
             <ul class="list-inline">
-              $for(links)$
+              $for(socials)$
               $for(it/pairs)$
               <li class="list-inline-item">
-                <a href=$it.value$>
+                <a href=$it.value.link$ target="_blank">
                   <button type="button" class="btn btn-outline-dark">
-                    $it.key$
+                    $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                   </button>
                 </a>
               </li>
@@ -49,11 +49,11 @@
           <div class="row justify-content-center align-items-center">
             <div class="col-8 m-1 text-center d-block d-sm-none">
               <div class="list-group">
-                $for(links)$
+                $for(socials)$
                 $for(it/pairs)$
-                <a href=$it.value$>
+                <a href=$it.value.link$ target="_blank">
                   <button type="button" class="list-group-item list-group-item-action my-1 rounded">
-                    $it.key$
+                    $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                   </button>
                 </a>
                 $endfor$

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -18,6 +18,10 @@
       }
     </style>
 
+    $if(favicon)$
+      <link rel="shortcut icon" href="$favicon$" />
+    $endif$
+
     <title>$title$</title>
 
   </head>

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -39,12 +39,12 @@
           </div>
           <div class="pl-5 pt-4" id="icon-list">
             <ul class="list-inline">
-              $for(links)$
+              $for(socials)$
               $for(it/pairs)$
               <li class="list-inline-item">
-                <a href=$it.value$>
+                <a href=$it.value.link$ target="_blank">
                   <button type="button" class="btn btn-outline-light">
-                    $it.key$
+                    $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                   </button>
                 </a>
               </li>
@@ -76,11 +76,11 @@
       <div class="row justify-content-center align-items-center pb-4">
           <div class="col-8 p-1 text-center">
               <div class="list-group">
-                $for(links)$
+                $for(socials)$
                 $for(it/pairs)$
-                <a href=$it.value$>
+                <a href=$it.value.link$ target="_blank">
                     <button type="button" class="list-group-item list-group-item-action my-1 rounded" style="background-color: Transparent; color:white; border-color: white;">
-                    $it.key$
+                      $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                     </button>
                 </a>
                 $endfor$

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -11,6 +11,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap" rel="stylesheet">
     <style type="text/css">body {font-family: 'Roboto Slab', serif;}</style>
 
+    $if(favicon)$
+      <link rel="shortcut icon" href="$favicon$" />
+    $endif$
+
     <title>$title$</title>
 
   </head>

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -29,13 +29,12 @@
             <div class="p-2">
               <div id="icon-list">
                 <ul class="list-inline">
-
-                  $for(links)$
+                  $for(socials)$
                   $for(it/pairs)$
                   <li class="list-inline-item">
-                    <a href=$it.value$>
-                      <button type="button" class="btn btn-outline-dark">
-                        $it.key$
+                    <a href=$it.value.link$ target="_blank">
+                      <button type="button" class="btn btn-outline-dark my-1 my-lg-0">
+                        $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
                       </button>
                     </a>
                   </li>
@@ -69,13 +68,15 @@
             <div class="row justify-content-center align-items-center">
               <div class="col-8 p-1 text-center">
                 <div class="list-group">
-                  $for(links)$
+                  $for(socials)$
                   $for(it/pairs)$
-                  <a href=$it.value$>
-                    <button type="button" class="list-group-item list-group-item-action my-1 rounded">
-                      $it.key$
-                    </button>
-                  </a>
+                  <li class="list-inline-item">
+                    <a href=$it.value.link$ target="_blank">
+                      <button type="button" class="btn btn-outline-dark my-1 my-lg-0">
+                        $if(it.value.icon)$$it.value.icon$$endif$ $it.key$
+                      </button>
+                    </a>
+                  </li>
                   $endfor$
                   $endfor$
                 </div>

--- a/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
@@ -1,11 +1,15 @@
 ---
 title: "Xiang Guo"
 image: "xiang.jpg"
-links:
-  - LinkedIn: "https://linkedin.com/"
-  - Twitter: "https://twitter.com/"
-  - GitHub: "https://github.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - LinkedIn: 
+      link: "https://linkedin.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - GitHub: 
+      link: "https://github.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::jolla_blue
 ---

--- a/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
@@ -1,11 +1,15 @@
 ---
 title: "Tobi Burns"
 image: "tobi.jpg"
-links:
-  - LinkedIn: "https://linkedin.com/"
-  - Twitter: "https://twitter.com/"
-  - GitHub: "https://github.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - LinkedIn: 
+      link: "https://linkedin.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - GitHub: 
+      link: "https://github.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::jolla
 ---

--- a/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
@@ -4,11 +4,15 @@ image: "herzl.jpg"
 color1: "#5A59A3"
 color2: "#C66060"
 angle: 130
-links:
-  - YouTube: "https://youtube.com/"
-  - Vimeo: "https://vimeo.com/"
-  - Twitter: "https://twitter.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - YouTube: 
+      link: "https://youtube.com/"
+  - Vimeo: 
+      link: "https://vimeo.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::onofre
 ---

--- a/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
@@ -1,11 +1,15 @@
 ---
 title: "Frank Hermosillo"
 image: "frank.jpg"
-links:
-  - LinkedIn: "https://linkedin.com/"
-  - Twitter: "https://twitter.com/"
-  - GitHub: "https://github.com/"
-  - Email: "mailto:email@email.com"
+socials:
+  - LinkedIn: 
+      link: "https://linkedin.com/"
+  - Twitter: 
+      link: "https://twitter.com/"
+  - GitHub: 
+      link: "https://github.com/"
+  - Email: 
+      link: "mailto:email@email.com"
 output:
   postcards::trestles
 ---


### PR DESCRIPTION
Hi @seankross,

Not sure if you're open to pull requests, but I really like this package and I wanted to add support for including `fontawesome` icons in the social buttons. So I modified the HTML templates to provide this support, and I thought I would pass these changes back to you to see if you want to include them in the package.

__Summary of changes:__
- Added support for including icons in the social buttons
  - Changed the top-level yaml variable to `socials`, so as to avoid confusion with the `link` argument
  - Added an optional argument called `icon` to include icons (such as with the amazing `fontawesome` package, shown below)
````yaml
---
title: "Frank Hermosillo"
image: "frank.jpg"
socials:
  - LinkedIn: 
      link: "https://linkedin.com/"
  - Twitter: 
      link: "https://twitter.com/"
      icon: '`r fontawesome::fa("twitter")`'
  - GitHub: 
      link: "https://github.com/"
  - Email: 
      link: "mailto:email@email.com"
output:
  postcards::trestles
---
````

- Added some margin spacing to the social buttons in the `trestles` theme for smaller screen sizes

- Updated the README and skeleton Rmd templates to reflect the changes described above

- Added `_target="blank"` to social button `<a>` tags to open link in new tab

- Added a top-level YAML variable `favicon` to enable favicon support