### PR TITLE
Enable injection of header, before/after body, and css fragments

### DIFF
--- a/R/postcards.R
+++ b/R/postcards.R
@@ -1,32 +1,36 @@
 #' Jolla website template.
 #'
+#' @inheritParams rmarkdown::html_document
 #' @export
-jolla <- function() {
-  get_template("jolla")
+jolla <- function(css = NULL, includes = NULL) {
+  get_template("jolla", css, includes)
 }
 
 #' Jolla Blue website template.
 #'
+#' @inheritParams rmarkdown::html_document
 #' @export
-jolla_blue <- function() {
+jolla_blue <- function(css = NULL, includes = NULL) {
   get_template("jolla-blue")
 }
 
 #' Jolla Blue website template.
 #'
+#' @inheritParams rmarkdown::html_document
 #' @export
-trestles <- function() {
+trestles <- function(css = NULL, includes = NULL) {
   get_template("trestles")
 }
 
 #' Onofre website template.
 #'
+#' @inheritParams rmarkdown::html_document
 #' @export
-onofre <- function() {
+onofre <- function(css = NULL, includes = NULL) {
   get_template("onofre")
 }
 
-get_template <- function(name) {
+get_template <- function(name, css, includes) {
 
   # Must we use "old" templates?
   minimum_required <- "2.8"
@@ -40,6 +44,8 @@ get_template <- function(name) {
     self_contained = self_contained,
     mathjax = NULL,
     template = system.file("pandoc_templates", template_file, package = "postcards"),
+    css = css,
+    includes = includes,
     md_extensions = "-autolink_bare_uris"
   )
 }

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -17,8 +17,21 @@
       <link rel="shortcut icon" href=$favicon$>
     $endif$
 
+    $for(header-includes)$
+      $header-includes$
+    $endfor$
+
+    $for(css)$
+      <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+    $endfor$
+
   </head>
   <body>
+
+    $for(include-before)$
+      $include-before$
+    $endfor$
+
     <div class="container min-vh-100">
       <div class="row min-vh-100 justify-content-center align-items-center">
         <div class="col-12 text-center">
@@ -75,5 +88,10 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+
+    $for(include-after)$
+      $include-after$
+    $endfor$
+
   </body>
 </html>

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -14,8 +14,21 @@
       <link rel="shortcut icon" href=$favicon$>
     $endif$
 
+    $for(header-includes)$
+      $header-includes$
+    $endfor$
+
+    $for(css)$
+      <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+    $endfor$
+
   </head>
   <body>
+
+    $for(include-before)$
+      $include-before$
+    $endfor$
+
     <div class="container min-vh-100">
       <div class="row min-vh-100 justify-content-center align-items-center">
         <div class="col-12 text-center">
@@ -72,5 +85,10 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+
+    $for(include-after)$
+      $include-after$
+    $endfor$
+
   </body>
 </html>

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -24,8 +24,21 @@
       <link rel="shortcut icon" href=$favicon$>
     $endif$
 
+    $for(header-includes)$
+      $header-includes$
+    $endfor$
+
+    $for(css)$
+      <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+    $endfor$
+
   </head>
   <body>
+
+    $for(include-before)$
+      $include-before$
+    $endfor$
+
     <div class="container-fluid min-vh-100 d-none d-md-block d-lg-block d-xl-block">
       <div class="row min-vh-100 align-items-center">
         <div class="col-12 col-lg-6">
@@ -95,5 +108,10 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+
+    $for(include-after)$
+      $include-after$
+    $endfor$
+
   </body>
 </html>

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -17,8 +17,21 @@
       <link rel="shortcut icon" href=$favicon$>
     $endif$
 
+    $for(header-includes)$
+      $header-includes$
+    $endfor$
+
+    $for(css)$
+      <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+    $endfor$
+
   </head>
   <body>
+
+    $for(include-before)$
+      $include-before$
+    $endfor$
+
     <div class="container-flex min-vh-100 d-none d-lg-block d-xl-block">
       <div class="d-flex flex-row">
         <div class="d-flex flex-col col-5 align-items-center min-vh-100 border-right text-center">
@@ -92,5 +105,10 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+
+  $for(include-after)$
+    $include-after$
+  $endfor$
+
   </body>
 </html>

--- a/man/jolla.Rd
+++ b/man/jolla.Rd
@@ -4,7 +4,13 @@
 \alias{jolla}
 \title{Jolla website template.}
 \usage{
-jolla()
+jolla(css = NULL, includes = NULL)
+}
+\arguments{
+\item{css}{One or more css files to include}
+
+\item{includes}{Named list of additional content to include within the
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 }
 \description{
 Jolla website template.

--- a/man/jolla_blue.Rd
+++ b/man/jolla_blue.Rd
@@ -4,7 +4,13 @@
 \alias{jolla_blue}
 \title{Jolla Blue website template.}
 \usage{
-jolla_blue()
+jolla_blue(css = NULL, includes = NULL)
+}
+\arguments{
+\item{css}{One or more css files to include}
+
+\item{includes}{Named list of additional content to include within the
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 }
 \description{
 Jolla Blue website template.

--- a/man/onofre.Rd
+++ b/man/onofre.Rd
@@ -4,7 +4,13 @@
 \alias{onofre}
 \title{Onofre website template.}
 \usage{
-onofre()
+onofre(css = NULL, includes = NULL)
+}
+\arguments{
+\item{css}{One or more css files to include}
+
+\item{includes}{Named list of additional content to include within the
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 }
 \description{
 Onofre website template.

--- a/man/trestles.Rd
+++ b/man/trestles.Rd
@@ -4,7 +4,13 @@
 \alias{trestles}
 \title{Jolla Blue website template.}
 \usage{
-trestles()
+trestles(css = NULL, includes = NULL)
+}
+\arguments{
+\item{css}{One or more css files to include}
+
+\item{includes}{Named list of additional content to include within the
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 }
 \description{
 Jolla Blue website template.


### PR DESCRIPTION
This enables users to provide custom CSS in the output format YAML, as well as enables additional custom <head> and header/footer content.

Motivation is to be able to include postcards as the "About" page of a Distill website (and we need to inject the Distill site header/footer, as well as related CSS and JS).