### PR TITLE
Fixed typo

### DIFF
--- a/R/postcards.R
+++ b/R/postcards.R
@@ -14,7 +14,7 @@ jolla_blue <- function(css = NULL, includes = NULL) {
   get_template("jolla-blue", css, includes)
 }
 
-#' Jolla Blue website template.
+#' Trestles website template.
 #'
 #' @inheritParams rmarkdown::html_document
 #' @export


### PR DESCRIPTION
Hi,
I noticed that there was a typo in the documentation for the Trestles template, it was referring to the Jolla Blue template.
This PR simply fixes that typo. Let me know if there's anything else I should do for this.
Thanks,

Alessandro