### PR TITLE
Add meta og tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ meta:
 ```
 These tags assume that `@yourname` is your twitter handle. Do not include the "@" because it confuses pandoc.
 The code also assumes that your image is going to be at the first level of your site, like: `yoursite.com/herzl.jpg`.
-You can edit the resulting index.html if that is not true. 
+
 Check your card with the twitter card validator. 
 
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ in New York City. "ГУМ" is their latest project which examines the rise of
 consumerism in post-Soviet republics.
 ```
 
+## Meta tags
+
+Each of the templates has an optional meta section. If you include it, the values 
+will be used to create social cards, like for twitter. 
+
+```
+meta:
+  description: "floatplane data artist"
+  url: "yoursite.com"
+  twitter: "yourname"
+```
+These tags assume that `@yourname` is your twitter handle. Do not include the "@" because it confuses pandoc.
+The code also assumes that your image is going to be at the first level of your site, like: `yoursite.com/herzl.jpg`.
+You can edit the resulting index.html if that is not true. 
+Check your card with the twitter card validator. 
+
+
 ## Troubleshooting
 
 Most issues that people have using this package are related their installation

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -21,7 +21,7 @@
       <meta name="og:title" content="$title$"></meta>
       <meta name="twitter:url" content="$meta.url$"></meta>
       <meta property="og:url" content="$meta.url$"></meta>
-      <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
+      <meta name="twitter:image:src" content="$if(meta.image)$$meta.image$$else$$meta.url$/$image$$endif$"></meta>
       <meta property="og:image" content="$meta.url$/$image$"></meta>
       <meta name="twitter:card" content="summary"></meta>
       <meta name="twitter:creator" content="@$meta.twitter$"></meta>

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -14,18 +14,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content=$meta.description$>
-      <meta name="twitter:description" content=$meta.description$/>
-      <meta name="og:description" content=$meta.description$/>
-      <meta name="twitter:title" content=$title$/>
-      <meta name="og:title" content=$title$/>
-      <meta name="twitter:url" content=$meta.url$/>
-      <meta property="og:url" content=$meta.url$/>
-      <meta name="twitter:image:src" content=$image$/>
-      <meta property="og:image" content=$image$/>
+      <meta name="description" content="$meta.description$">
+      <meta name="twitter:description" content="$meta.description$"/>
+      <meta name="og:description" content="$meta.description$"/>
+      <meta name="twitter:title" content="$title$"/>
+      <meta name="og:title" content="$title$"/>
+      <meta name="twitter:url" content="$meta.url$"/>
+      <meta property="og:url" content="$meta.url$"/>
+      <meta name="twitter:image:src" content="$image$"/>
+      <meta property="og:image" content="$image$"/>
       <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content=$meta.twitter$/>
-      <meta name="twitter:site" content=$meta.twitter$/>
+      <meta name="twitter:creator" content="@$meta.twitter$"/>
+      <meta name="twitter:site" content="@$meta.twitter$"/>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -12,6 +12,21 @@
     <style type="text/css">body {background-color: #3A66B7;font-family: 'Merriweather', serif;color: #FEFEFA;}</style>
 
     <title>$title$</title>
+    
+    $if(meta)$
+      <meta name="description" content=$meta.description$>
+      <meta name="twitter:description" content=$meta.description$/>
+      <meta name="og:description" content=$meta.description$/>
+      <meta name="twitter:title" content=$title$/>
+      <meta name="og:title" content=$title$/>
+      <meta name="twitter:url" content=$meta.url$/>
+      <meta property="og:url" content=$meta.url$/>
+      <meta name="twitter:image:src" content=$image$/>
+      <meta property="og:image" content=$image$/>
+      <meta name="twitter:card" content="summary"/>
+      <meta name="twitter:creator" content=$meta.twitter$/>
+      <meta name="twitter:site" content=$meta.twitter$/>
+    $endif$
 
     $if(favicon)$
       <link rel="shortcut icon" href=$favicon$>

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -24,8 +24,10 @@
       <meta name="twitter:image:src" content="$if(meta.image)$$meta.image$$else$$meta.url$/$image$$endif$"></meta>
       <meta property="og:image" content="$meta.url$/$image$"></meta>
       <meta name="twitter:card" content="summary"></meta>
+      $if(twitter)$
       <meta name="twitter:creator" content="@$meta.twitter$"></meta>
       <meta name="twitter:site" content="@$meta.twitter$"></meta>
+    $endif$
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -14,18 +14,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content="$meta.description$">
-      <meta name="twitter:description" content="$meta.description$"/>
-      <meta name="og:description" content="$meta.description$"/>
-      <meta name="twitter:title" content="$title$"/>
-      <meta name="og:title" content="$title$"/>
-      <meta name="twitter:url" content="$meta.url$"/>
-      <meta property="og:url" content="$meta.url$"/>
-      <meta name="twitter:image:src" content="$image$"/>
-      <meta property="og:image" content="$image$"/>
-      <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content="@$meta.twitter$"/>
-      <meta name="twitter:site" content="@$meta.twitter$"/>
+    <meta name="description" content="$meta.description$"></meta>
+      <meta name="twitter:description" content="$meta.description$"></meta>
+      <meta name="og:description" content="$meta.description$"></meta>
+      <meta name="twitter:title" content="$title$"></meta>
+      <meta name="og:title" content="$title$"></meta>
+      <meta name="twitter:url" content="$meta.url$"></meta>
+      <meta property="og:url" content="$meta.url$"></meta>
+      <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
+      <meta property="og:image" content="$meta.url$/$image$"></meta>
+      <meta name="twitter:card" content="summary"></meta>
+      <meta name="twitter:creator" content="@$meta.twitter$"></meta>
+      <meta name="twitter:site" content="@$meta.twitter$"></meta>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -11,18 +11,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content=$meta.description$>
-      <meta name="twitter:description" content=$meta.description$/>
-      <meta name="og:description" content=$meta.description$/>
-      <meta name="twitter:title" content=$title$/>
-      <meta name="og:title" content=$title$/>
-      <meta name="twitter:url" content=$meta.url$/>
-      <meta property="og:url" content=$meta.url$/>
-      <meta name="twitter:image:src" content=$image$/>
-      <meta property="og:image" content=$image$/>
+      <meta name="description" content="$meta.description$">
+      <meta name="twitter:description" content="$meta.description$"/>
+      <meta name="og:description" content="$meta.description$"/>
+      <meta name="twitter:title" content="$title$"/>
+      <meta name="og:title" content="$title$"/>
+      <meta name="twitter:url" content="$meta.url$"/>
+      <meta property="og:url" content="$meta.url$"/>
+      <meta name="twitter:image:src" content="$image$"/>
+      <meta property="og:image" content="$image$"/>
       <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content=$meta.twitter$/>
-      <meta name="twitter:site" content=$meta.twitter$/>
+      <meta name="twitter:creator" content="$meta.twitter$"/>
+      <meta name="twitter:site" content="$meta.twitter$"/>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -21,8 +21,8 @@
       <meta name="twitter:image:src" content="$image$"/>
       <meta property="og:image" content="$image$"/>
       <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content="$meta.twitter$"/>
-      <meta name="twitter:site" content="$meta.twitter$"/>
+      <meta name="twitter:creator" content="@$meta.twitter$"/>
+      <meta name="twitter:site" content="@$meta.twitter$"/>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -11,18 +11,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content="$meta.description$">
-      <meta name="twitter:description" content="$meta.description$"/>
-      <meta name="og:description" content="$meta.description$"/>
-      <meta name="twitter:title" content="$title$"/>
-      <meta name="og:title" content="$title$"/>
-      <meta name="twitter:url" content="$meta.url$"/>
-      <meta property="og:url" content="$meta.url$"/>
-      <meta name="twitter:image:src" content="$image$"/>
-      <meta property="og:image" content="$image$"/>
-      <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content="@$meta.twitter$"/>
-      <meta name="twitter:site" content="@$meta.twitter$"/>
+    <meta name="description" content="$meta.description$"></meta>
+      <meta name="twitter:description" content="$meta.description$"></meta>
+      <meta name="og:description" content="$meta.description$"></meta>
+      <meta name="twitter:title" content="$title$"></meta>
+      <meta name="og:title" content="$title$"></meta>
+      <meta name="twitter:url" content="$meta.url$"></meta>
+      <meta property="og:url" content="$meta.url$"></meta>
+      <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
+      <meta property="og:image" content="$meta.url$/$image$"></meta>
+      <meta name="twitter:card" content="summary"></meta>
+      <meta name="twitter:creator" content="@$meta.twitter$"></meta>
+      <meta name="twitter:site" content="@$meta.twitter$"></meta>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -21,8 +21,10 @@
       <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
       <meta property="og:image" content="$meta.url$/$image$"></meta>
       <meta name="twitter:card" content="summary"></meta>
+      $if(twitter)$
       <meta name="twitter:creator" content="@$meta.twitter$"></meta>
       <meta name="twitter:site" content="@$meta.twitter$"></meta>
+    $endif$
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -9,6 +9,21 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
 
     <title>$title$</title>
+    
+    $if(meta)$
+      <meta name="description" content=$meta.description$>
+      <meta name="twitter:description" content=$meta.description$/>
+      <meta name="og:description" content=$meta.description$/>
+      <meta name="twitter:title" content=$title$/>
+      <meta name="og:title" content=$title$/>
+      <meta name="twitter:url" content=$meta.url$/>
+      <meta property="og:url" content=$meta.url$/>
+      <meta name="twitter:image:src" content=$image$/>
+      <meta property="og:image" content=$image$/>
+      <meta name="twitter:card" content="summary"/>
+      <meta name="twitter:creator" content=$meta.twitter$/>
+      <meta name="twitter:site" content=$meta.twitter$/>
+    $endif$
 
     $if(favicon)$
       <link rel="shortcut icon" href=$favicon$>

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -21,7 +21,7 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content="$meta.description$">
+    <meta name="description" content="$meta.description$">
       <meta name="twitter:description" content="$meta.description$">
       <meta name="og:description" content="$meta.description$">
       <meta name="twitter:title" content="$title$">

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -19,6 +19,21 @@
     </style>
 
     <title>$title$</title>
+    
+    $if(meta)$
+      <meta name="description" content=$meta.description$>
+      <meta name="twitter:description" content=$meta.description$/>
+      <meta name="og:description" content=$meta.description$/>
+      <meta name="twitter:title" content=$title$/>
+      <meta name="og:title" content=$title$/>
+      <meta name="twitter:url" content=$meta.url$/>
+      <meta property="og:url" content=$meta.url$/>
+      <meta name="twitter:image:src" content=$image$/>
+      <meta property="og:image" content=$image$/>
+      <meta name="twitter:card" content="summary"/>
+      <meta name="twitter:creator" content=$meta.twitter$/>
+      <meta name="twitter:site" content=$meta.twitter$/>
+    $endif$
 
     $if(favicon)$
       <link rel="shortcut icon" href=$favicon$>

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -21,18 +21,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content=$meta.description$>
-      <meta name="twitter:description" content=$meta.description$/>
-      <meta name="og:description" content=$meta.description$/>
-      <meta name="twitter:title" content=$title$/>
-      <meta name="og:title" content=$title$/>
-      <meta name="twitter:url" content=$meta.url$/>
-      <meta property="og:url" content=$meta.url$/>
-      <meta name="twitter:image:src" content=$image$/>
-      <meta property="og:image" content=$image$/>
+      <meta name="description" content="$meta.description$">
+      <meta name="twitter:description" content="$meta.description$"/>
+      <meta name="og:description" content="$meta.description$"/>
+      <meta name="twitter:title" content="$title$"/>
+      <meta name="og:title" content="$title$"/>
+      <meta name="twitter:url" content="$meta.url$"/>
+      <meta property="og:url" content="$meta.url$"/>
+      <meta name="twitter:image:src" content="$image$"/>
+      <meta property="og:image" content="$image$"/>
       <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content=$meta.twitter$/>
-      <meta name="twitter:site" content=$meta.twitter$/>
+      <meta name="twitter:creator" content="@$meta.twitter$"/>
+      <meta name="twitter:site" content="@$meta.twitter$"/>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -22,17 +22,17 @@
     
     $if(meta)$
       <meta name="description" content="$meta.description$">
-      <meta name="twitter:description" content="$meta.description$"/>
-      <meta name="og:description" content="$meta.description$"/>
-      <meta name="twitter:title" content="$title$"/>
-      <meta name="og:title" content="$title$"/>
-      <meta name="twitter:url" content="$meta.url$"/>
-      <meta property="og:url" content="$meta.url$"/>
-      <meta name="twitter:image:src" content="$image$"/>
-      <meta property="og:image" content="$image$"/>
-      <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content="@$meta.twitter$"/>
-      <meta name="twitter:site" content="@$meta.twitter$"/>
+      <meta name="twitter:description" content="$meta.description$">
+      <meta name="og:description" content="$meta.description$">
+      <meta name="twitter:title" content="$title$">
+      <meta name="og:title" content="$title$">
+      <meta name="twitter:url" content="$meta.url$">
+      <meta property="og:url" content="$meta.url$">
+      <meta name="twitter:image:src" content="$image$">
+      <meta property="og:image" content="$image$">
+      <meta name="twitter:card" content="summary">
+      <meta name="twitter:creator" content="@$meta.twitter$">
+      <meta name="twitter:site" content="@$meta.twitter$">
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -31,8 +31,10 @@
       <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
       <meta property="og:image" content="$meta.url$/$image$"></meta>
       <meta name="twitter:card" content="summary"></meta>
+    $if(twitter)$
       <meta name="twitter:creator" content="@$meta.twitter$"></meta>
       <meta name="twitter:site" content="@$meta.twitter$"></meta>
+    $endif$
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -21,18 +21,18 @@
     <title>$title$</title>
     
     $if(meta)$
-    <meta name="description" content="$meta.description$">
-      <meta name="twitter:description" content="$meta.description$">
-      <meta name="og:description" content="$meta.description$">
-      <meta name="twitter:title" content="$title$">
-      <meta name="og:title" content="$title$">
-      <meta name="twitter:url" content="$meta.url$">
-      <meta property="og:url" content="$meta.url$">
-      <meta name="twitter:image:src" content="$image$">
-      <meta property="og:image" content="$image$">
-      <meta name="twitter:card" content="summary">
-      <meta name="twitter:creator" content="@$meta.twitter$">
-      <meta name="twitter:site" content="@$meta.twitter$">
+    <meta name="description" content="$meta.description$"></meta>
+      <meta name="twitter:description" content="$meta.description$"></meta>
+      <meta name="og:description" content="$meta.description$"></meta>
+      <meta name="twitter:title" content="$title$"></meta>
+      <meta name="og:title" content="$title$"></meta>
+      <meta name="twitter:url" content="$meta.url$"></meta>
+      <meta property="og:url" content="$meta.url$"></meta>
+      <meta name="twitter:image:src" content="$image$"></meta>
+      <meta property="og:image" content="$image$"></meta>
+      <meta name="twitter:card" content="summary"></meta>
+      <meta name="twitter:creator" content="@$meta.twitter$"></meta>
+      <meta name="twitter:site" content="@$meta.twitter$"></meta>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -28,8 +28,8 @@
       <meta name="og:title" content="$title$"></meta>
       <meta name="twitter:url" content="$meta.url$"></meta>
       <meta property="og:url" content="$meta.url$"></meta>
-      <meta name="twitter:image:src" content="$image$"></meta>
-      <meta property="og:image" content="$image$"></meta>
+      <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
+      <meta property="og:image" content="$meta.url$/$image$"></meta>
       <meta name="twitter:card" content="summary"></meta>
       <meta name="twitter:creator" content="@$meta.twitter$"></meta>
       <meta name="twitter:site" content="@$meta.twitter$"></meta>

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -24,8 +24,10 @@
       <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
       <meta property="og:image" content="$meta.url$/$image$"></meta>
       <meta name="twitter:card" content="summary"></meta>
+      $if(twitter)$
       <meta name="twitter:creator" content="@$meta.twitter$"></meta>
       <meta name="twitter:site" content="@$meta.twitter$"></meta>
+    $endif$
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -12,6 +12,21 @@
     <style type="text/css">body {font-family: 'Roboto Slab', serif;}</style>
 
     <title>$title$</title>
+    
+    $if(meta)$
+      <meta name="description" content=$meta.description$>
+      <meta name="twitter:description" content=$meta.description$/>
+      <meta name="og:description" content=$meta.description$/>
+      <meta name="twitter:title" content=$title$/>
+      <meta name="og:title" content=$title$/>
+      <meta name="twitter:url" content=$meta.url$/>
+      <meta property="og:url" content=$meta.url$/>
+      <meta name="twitter:image:src" content=$image$/>
+      <meta property="og:image" content=$image$/>
+      <meta name="twitter:card" content="summary"/>
+      <meta name="twitter:creator" content=$meta.twitter$/>
+      <meta name="twitter:site" content=$meta.twitter$/>
+    $endif$
 
     $if(favicon)$
       <link rel="shortcut icon" href=$favicon$>

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -14,18 +14,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content=$meta.description$>
-      <meta name="twitter:description" content=$meta.description$/>
-      <meta name="og:description" content=$meta.description$/>
-      <meta name="twitter:title" content=$title$/>
-      <meta name="og:title" content=$title$/>
-      <meta name="twitter:url" content=$meta.url$/>
-      <meta property="og:url" content=$meta.url$/>
-      <meta name="twitter:image:src" content=$image$/>
-      <meta property="og:image" content=$image$/>
+      <meta name="description" content="$meta.description$">
+      <meta name="twitter:description" content="$meta.description$"/>
+      <meta name="og:description" content="$meta.description$"/>
+      <meta name="twitter:title" content="$title$"/>
+      <meta name="og:title" content="$title$"/>
+      <meta name="twitter:url" content="$meta.url$"/>
+      <meta property="og:url" content="$meta.url$"/>
+      <meta name="twitter:image:src" content="$image$"/>
+      <meta property="og:image" content="$image$"/>
       <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content=$meta.twitter$/>
-      <meta name="twitter:site" content=$meta.twitter$/>
+      <meta name="twitter:creator" content="@$meta.twitter$"/>
+      <meta name="twitter:site" content="@$meta.twitter$"/>
     $endif$
 
     $if(favicon)$

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -14,18 +14,18 @@
     <title>$title$</title>
     
     $if(meta)$
-      <meta name="description" content="$meta.description$">
-      <meta name="twitter:description" content="$meta.description$"/>
-      <meta name="og:description" content="$meta.description$"/>
-      <meta name="twitter:title" content="$title$"/>
-      <meta name="og:title" content="$title$"/>
-      <meta name="twitter:url" content="$meta.url$"/>
-      <meta property="og:url" content="$meta.url$"/>
-      <meta name="twitter:image:src" content="$image$"/>
-      <meta property="og:image" content="$image$"/>
-      <meta name="twitter:card" content="summary"/>
-      <meta name="twitter:creator" content="@$meta.twitter$"/>
-      <meta name="twitter:site" content="@$meta.twitter$"/>
+    <meta name="description" content="$meta.description$"></meta>
+      <meta name="twitter:description" content="$meta.description$"></meta>
+      <meta name="og:description" content="$meta.description$"></meta>
+      <meta name="twitter:title" content="$title$"></meta>
+      <meta name="og:title" content="$title$"></meta>
+      <meta name="twitter:url" content="$meta.url$"></meta>
+      <meta property="og:url" content="$meta.url$"></meta>
+      <meta name="twitter:image:src" content="$meta.url$/$image$"></meta>
+      <meta property="og:image" content="$meta.url$/$image$"></meta>
+      <meta name="twitter:card" content="summary"></meta>
+      <meta name="twitter:creator" content="@$meta.twitter$"></meta>
+      <meta name="twitter:site" content="@$meta.twitter$"></meta>
     $endif$
 
     $if(favicon)$

--- a/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
@@ -10,6 +10,10 @@ links:
     url: "https://github.com/"
   - label: Email
     url: "mailto:email@email.com"
+meta:
+  - description: "floatplane data artist"
+  - url: "yoursite.com"
+  - twitter: "@yourname"
 output:
   postcards::jolla_blue
 ---

--- a/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
@@ -13,7 +13,7 @@ links:
 meta:
   description: "floatplane data artist"
   url: "yoursite.com"
-  twitter: "@yourname"
+  twitter: "yourname"
 output:
   postcards::jolla_blue
 ---

--- a/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
@@ -11,9 +11,9 @@ links:
   - label: Email
     url: "mailto:email@email.com"
 meta:
-  - description: "floatplane data artist"
-  - url: "yoursite.com"
-  - twitter: "@yourname"
+  description: "floatplane data artist"
+  url: "yoursite.com"
+  twitter: "@yourname"
 output:
   postcards::jolla_blue
 ---

--- a/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
@@ -11,9 +11,9 @@ links:
   - label: Email
     url: "mailto:email@email.com"
 meta:
-  - description: "floatplane data artist"
-  - url: "yoursite.com"
-  - twitter: "@yourname"
+  description: "floatplane data artist"
+  url: "yoursite.com"
+  twitter: "@yourname"
 output:
   postcards::jolla
 ---

--- a/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
@@ -13,7 +13,7 @@ links:
 meta:
   description: "floatplane data artist"
   url: "yoursite.com"
-  twitter: "@yourname"
+  twitter: "yourname"
 output:
   postcards::jolla
 ---

--- a/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
@@ -10,6 +10,10 @@ links:
     url: "https://github.com/"
   - label: Email
     url: "mailto:email@email.com"
+meta:
+  - description: "floatplane data artist"
+  - url: "yoursite.com"
+  - twitter: "@yourname"
 output:
   postcards::jolla
 ---

--- a/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
@@ -14,9 +14,9 @@ links:
   - label: Email
     url: "mailto:email@email.com"
 meta:
-  - description: "floatplane data artist"
-  - url: "yoursite.com"
-  - twitter: "@yourname"
+  description: "floatplane data artist"
+  url: "yoursite.com"
+  twitter: "@yourname"
 output:
   postcards::onofre
 ---

--- a/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
@@ -16,7 +16,7 @@ links:
 meta:
   description: "floatplane data artist"
   url: "yoursite.com"
-  twitter: "@yourname"
+  twitter: "yourname"
 output:
   postcards::onofre
 ---

--- a/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
@@ -13,6 +13,10 @@ links:
     url: "https://twitter.com/"
   - label: Email
     url: "mailto:email@email.com"
+meta:
+  - description: "floatplane data artist"
+  - url: "yoursite.com"
+  - twitter: "@yourname"
 output:
   postcards::onofre
 ---

--- a/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
@@ -10,6 +10,10 @@ links:
     url: "https://github.com/"
   - label: Email
     url: "mailto:email@email.com"
+meta:
+  - description: "floatplane data artist"
+  - url: "yoursite.com"
+  - twitter: "@yourname"
 output:
   postcards::trestles
 ---

--- a/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
@@ -11,9 +11,9 @@ links:
   - label: Email
     url: "mailto:email@email.com"
 meta:
-  - description: "floatplane data artist"
-  - url: "yoursite.com"
-  - twitter: "@yourname"
+  description: "floatplane data artist"
+  url: "yoursite.com"
+  twitter: "@yourname"
 output:
   postcards::trestles
 ---

--- a/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
@@ -13,7 +13,7 @@ links:
 meta:
   description: "floatplane data artist"
   url: "yoursite.com"
-  twitter: "@yourname"
+  twitter: "yourname"
 output:
   postcards::trestles
 ---


### PR DESCRIPTION
changes all templates in Pandoc (html) and skeleton (rmd) to allow for automatic meta/og tags without installing another package. 

closes #32 

relies on the already included `title` and `image` information. 

**Using this in the yaml:**

```{yaml}
meta:
  description: "data.coffee.run"
  url: "https://monkeywithacupcake.github.io"
  twitter: "jessachandler"
```

**results in this in the html header: **

```{html}
 <meta name="description" content="data.coffee.run" />
      <meta name="twitter:description" content="data.coffee.run" />
      <meta name="og:description" content="data.coffee.run" />
      <meta name="twitter:title" content="Cheers!" />
      <meta name="og:title" content="Cheers!" />
      <meta name="twitter:url" content="https://monkeywithacupcake.github.io" />
      <meta property="og:url" content="https://monkeywithacupcake.github.io" />
      <meta name="twitter:image:src" content="https://monkeywithacupcake.github.io/jess.jpg" />
      <meta property="og:image" content="https://monkeywithacupcake.github.io/jess.jpg" />
      <meta name="twitter:card" content="summary" />
      <meta name="twitter:creator" content="@jessachandler" />
      <meta name="twitter:site" content="@jessachandler" />
```

**and this twitter card:**

<img width="401" alt="Screen Shot of twitter card validator" src="https://user-images.githubusercontent.com/7316730/113462188-85149300-93d4-11eb-9988-13de8c58394a.png">

