### PR TITLE
add rel link attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ image: "tobi.jpg"
 links:
   - label: LinkedIn
     url: "https://linkedin.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: GitHub
     url: "https://github.com/"
   - label: Email
@@ -102,8 +103,9 @@ image: "xiang.jpg"
 links:
   - label: LinkedIn
     url: "https://linkedin.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: GitHub
     url: "https://github.com/"
   - label: Email
@@ -129,8 +131,9 @@ image: "frank.jpg"
 links:
   - label: LinkedIn
     url: "https://linkedin.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: GitHub
     url: "https://github.com/"
   - label: Email
@@ -181,8 +184,9 @@ links:
     url: "https://youtube.com/"
   - label: Vimeo
     url: "https://vimeo.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: Email
     url: "mailto:email@email.com"
 output:
@@ -211,8 +215,9 @@ links:
     url: "https://medium.com/"
   - label: SoundCloud
     url: "https://soundcloud.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
 output:
   postcards::solana
 ---

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -70,7 +70,7 @@
             <div class="col-8 m-1 text-center d-block d-sm-none">
               <div class="list-group">
                 $for(links)$
-                <a href=$links.url$>
+                <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                   <button type="button" class="list-group-item list-group-item-action my-1 rounded" style="background-color: #3A66B7;color: #FEFEFA;border-color: #FEFEFA;">
                     $links.label$
                   </button>

--- a/inst/pandoc_templates/jolla-blue.html
+++ b/inst/pandoc_templates/jolla-blue.html
@@ -55,7 +55,7 @@
               <ul class="list-inline">
                 $for(links)$
                 <li class="list-inline-item">
-                  <a href=$links.url$>
+                  <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                     <button type="button" class="btn btn-outline-light mb-2">
                       $links.label$
                     </button>

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -67,7 +67,7 @@
             <div class="col-8 m-1 text-center d-block d-sm-none">
               <div class="list-group">
                 $for(links)$
-                <a href=$links.url$>
+                <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                   <button type="button" class="list-group-item list-group-item-action my-1 rounded">
                     $links.label$
                   </button>

--- a/inst/pandoc_templates/jolla.html
+++ b/inst/pandoc_templates/jolla.html
@@ -52,7 +52,7 @@
               <ul class="list-inline">
                 $for(links)$
                 <li class="list-inline-item">
-                  <a href=$links.url$>
+                  <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                     <button type="button" class="btn btn-outline-dark mb-2">
                       $links.label$
                     </button>

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -58,7 +58,7 @@
             <ul class="list-inline">
               $for(links)$
               <li class="list-inline-item">
-                <a href=$links.url$>
+                <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                   <button type="button" class="btn btn-outline-light mb-2">
                     $links.label$
                   </button>

--- a/inst/pandoc_templates/onofre.html
+++ b/inst/pandoc_templates/onofre.html
@@ -92,7 +92,7 @@
           <div class="col-8 p-1 text-center">
               <div class="list-group">
                 $for(links)$
-                <a href=$links.url$>
+                <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                     <button type="button" class="list-group-item list-group-item-action my-1 rounded" style="background-color: Transparent; color:white; border-color: white;">
                     $links.label$
                     </button>

--- a/inst/pandoc_templates/solana.html
+++ b/inst/pandoc_templates/solana.html
@@ -53,7 +53,7 @@
             <ul class="list-inline">
               $for(links)$
               <li class="list-inline-item">
-                <a href=$links.url$>
+                <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                   <button type="button" class="btn btn-outline-dark mb-2">
                     $links.label$
                   </button>

--- a/inst/pandoc_templates/solana.html
+++ b/inst/pandoc_templates/solana.html
@@ -91,7 +91,7 @@
               <div class="col-8 p-1 text-center">
                 <div class="list-group">
                   $for(links)$
-                  <a href=$links.url$>
+                  <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                     <button type="button" class="list-group-item list-group-item-action my-1 rounded" style="background-color: #f5e9dd; color: black;border-color: black;">
                       $links.label$
                     </button>

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -85,7 +85,7 @@
               <div class="col-8 p-1 text-center">
                 <div class="list-group">
                   $for(links)$
-                  <a href=$links.url$>
+                  <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                     <button type="button" class="list-group-item list-group-item-action my-1 rounded">
                       $links.label$
                     </button>

--- a/inst/pandoc_templates/trestles.html
+++ b/inst/pandoc_templates/trestles.html
@@ -48,7 +48,7 @@
                 <ul class="list-inline">
                   $for(links)$
                   <li class="list-inline-item">
-                    <a href=$links.url$>
+                    <a href=$links.url$ $if(links.rel)$ rel=$links.rel$ $endif$>
                       <button type="button" class="btn btn-outline-dark mb-2">
                         $links.label$
                       </button>

--- a/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla-blue/skeleton/skeleton.Rmd
@@ -4,8 +4,9 @@ image: "xiang.jpg"
 links:
   - label: LinkedIn
     url: "https://linkedin.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: GitHub
     url: "https://github.com/"
   - label: Email

--- a/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jolla/skeleton/skeleton.Rmd
@@ -4,8 +4,9 @@ image: "tobi.jpg"
 links:
   - label: LinkedIn
     url: "https://linkedin.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: GitHub
     url: "https://github.com/"
   - label: Email

--- a/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/onofre/skeleton/skeleton.Rmd
@@ -9,8 +9,9 @@ links:
     url: "https://youtube.com/"
   - label: Vimeo
     url: "https://vimeo.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: Email
     url: "mailto:email@email.com"
 output:

--- a/inst/rmarkdown/templates/solana/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/solana/skeleton/skeleton.Rmd
@@ -8,8 +8,9 @@ links:
     url: "https://medium.com/"
   - label: SoundCloud
     url: "https://soundcloud.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
 output:
   postcards::solana
 ---

--- a/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/trestles/skeleton/skeleton.Rmd
@@ -4,8 +4,9 @@ image: "frank.jpg"
 links:
   - label: LinkedIn
     url: "https://linkedin.com/"
-  - label: Twitter
-    url: "https://twitter.com/"
+  - label: Mastodon
+    rel: me
+    url: "https://example.social/\\@username"
   - label: GitHub
     url: "https://github.com/"
   - label: Email


### PR DESCRIPTION
This PR adds a `rel` attribute to `links`. For example, `rel="me"` is used by Mastodon for [link verification](https://docs.joinmastodon.org/user/profile/#verification). 

I changed the Twitter links to Mastodon for illustration (it also shows how to add the Mastodon user name with `@`, cf. #57).

See it in action on my [site](https://possenrie.de/) ([mastodon](https://mas.to/@dpprdan), [source](https://github.com/dpprdan/landingpage/blob/main/index.Rmd)).

I noticed that there are two `div` blocks for the links in the pandoc templates. For example in the jolla template here:

https://github.com/seankross/postcards/blob/8f92e4ddc048ca02786f997814abe85fc953f5be/inst/pandoc_templates/jolla.html#L50-L64

and here

https://github.com/seankross/postcards/blob/8f92e4ddc048ca02786f997814abe85fc953f5be/inst/pandoc_templates/jolla.html#L66-L77

Is it necessary to have both and if yes, what for?